### PR TITLE
[MAINTENANCE] #7 - Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/navigatorsguild/command-executor"
 readme = "README.md"
 keywords = ["threadpool", "concurrency", "producer", "consumer", "mpmc"]
 categories = ["concurrency", ]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 [badges]


### PR DESCRIPTION
Bump version to 0.2.0 for release with dependency updates and clippy fixes.

Closes #7